### PR TITLE
Fix crash when a bad API response is returned

### DIFF
--- a/app/src/main/java/ch/coredump/watertemp/Config.kt
+++ b/app/src/main/java/ch/coredump/watertemp/Config.kt
@@ -1,0 +1,7 @@
+package ch.coredump.watertemp
+
+class Config {
+    companion object {
+        const val SUPPORT_EMAIL = "gfroerli@coredump.ch"
+    }
+}

--- a/app/src/main/java/ch/coredump/watertemp/activities/MapActivity.kt
+++ b/app/src/main/java/ch/coredump/watertemp/activities/MapActivity.kt
@@ -12,6 +12,7 @@ import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import ch.coredump.watertemp.BuildConfig
+import ch.coredump.watertemp.Config
 import ch.coredump.watertemp.R
 import ch.coredump.watertemp.Utils
 import ch.coredump.watertemp.rest.ApiClient
@@ -227,11 +228,12 @@ class MapActivity : AppCompatActivity(), OnMapReadyCallback {
                 // Handle unsuccessful response
                 if (!response.isSuccessful) {
                     val error = ApiClient.parseError(response)
-                    Log.e(TAG, error.toString())
+                    Log.e(TAG, "Could not fetch sensors (HTTP " + error.statusCode + "): " + error.message)
                     Utils.showError(
                         this@MapActivity,
-                        "Could not fetch sensors.\n ${error.statusCode}: ${error.message}"
+                        getString(R.string.fetching_sensor_data_failed, error.statusCode, Config.SUPPORT_EMAIL)
                     )
+                    return
                 }
 
                 // Success!

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -22,6 +22,7 @@
     <string name="chart_no_data">Keine Daten vorhanden</string>
     <string name="temperature">Temperatur</string>
     <string name="section_subheader_summary">Zusammenfassung (insgesamt)</string>
+    <string name="fetching_sensor_data_failed">Sensor-Daten konnten nicht geladen werden (HTTP %1$d).\nWenn das Problem fortbesteht, kontaktieren Sie bitte %2$s.</string>
     <string name="fetching_data_failed">%1$s konnten nicht geladen werden. Bitte prüfe deine Internetverbindung.</string>
     <string name="data_sensors">Sensoren</string>
     <string name="data_sensor_details">Sensor-Details</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,6 +34,7 @@
     <string name="action_refresh">Reload data</string>
 
     <!-- Error messages -->
+    <string name="fetching_sensor_data_failed">Could not fetch sensors (HTTP %1$d).\nIf the problem persists, please contact %2$s.</string>
     <string name="fetching_data_failed">Fetching %1$s failed. Please check your internet connection.</string>
     <!-- Shown in "fetching data failed" error message -->
     <string name="data_sensor_details">sensor details</string>


### PR DESCRIPTION
A `return` statement was missing.

Additionally, I improved the error message.

Fixes #34.