### PR TITLE
Switch from Mapbox SDK to Maplibre SDK

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,9 +67,9 @@ dependencies {
     implementation 'com.google.android.material:material:1.4.0-alpha01'
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
 
-    // Mapbox SDK
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:9.2.1' // Note: 9.3+ switches to proprietary components
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v9:0.9.0'
+    // Maplibre SDK
+    implementation 'org.maplibre.gl:android-sdk:9.2.1'
+    implementation 'org.maplibre.gl:android-plugin-annotation-v9:1.0.0'
 
     // REST client
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'

--- a/app/src/main/java/ch/coredump/watertemp/activities/MapActivity.kt
+++ b/app/src/main/java/ch/coredump/watertemp/activities/MapActivity.kt
@@ -31,7 +31,6 @@ import com.github.mikephil.charting.data.LineDataSet
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.gson.JsonObject
 import com.google.gson.JsonPrimitive
-import com.mapbox.android.telemetry.TelemetryEnabler
 import com.mapbox.mapboxsdk.Mapbox
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory
 import com.mapbox.mapboxsdk.geometry.LatLng
@@ -39,7 +38,6 @@ import com.mapbox.mapboxsdk.geometry.LatLngBounds
 import com.mapbox.mapboxsdk.maps.MapboxMap
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback
 import com.mapbox.mapboxsdk.maps.Style
-import com.mapbox.mapboxsdk.maps.TelemetryDefinition
 import com.mapbox.mapboxsdk.plugins.annotation.Symbol
 import com.mapbox.mapboxsdk.plugins.annotation.SymbolManager
 import com.mapbox.mapboxsdk.plugins.annotation.SymbolOptions
@@ -94,13 +92,6 @@ class MapActivity : AppCompatActivity(), OnMapReadyCallback {
 
         // Initialize mapbox
         Mapbox.getInstance(this, BuildConfig.MAPBOX_ACCESS_TOKEN)
-
-        val telemetry: TelemetryDefinition? = Mapbox.getTelemetry()
-        if (telemetry != null) {
-            Log.i(TAG, "Disable MapBox telemetry")
-            telemetry.setUserTelemetryRequestState(false)
-            TelemetryEnabler.updateTelemetryState(TelemetryEnabler.State.DISABLED)
-        }
 
         // Initialize the layout
         setContentView(R.layout.activity_map)

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,9 @@ buildscript {
     ext.kotlin_version = '1.5.20'
 
     repositories {
-        jcenter()
+        mavenCentral()
         google()
+        jcenter()
     }
 
     dependencies {
@@ -18,9 +19,10 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
         maven { url "https://jitpack.io" }
+        jcenter()
     }
 }
 


### PR DESCRIPTION
This also gets rid of all telemetry. (It was already disabled before, but now the entire code is gone, which is better.)

Refs #38.