### PR TITLE
Show grab handle on bottom sheet peek

### DIFF
--- a/app/src/main/java/ch/coredump/watertemp/activities/MapActivity.kt
+++ b/app/src/main/java/ch/coredump/watertemp/activities/MapActivity.kt
@@ -56,6 +56,7 @@ import java.util.*
 private const val MARKER_DEFAULT = "marker_default"
 private const val MARKER_ACTIVE = "marker_active"
 
+// Log tag
 private const val TAG = "MapActivity"
 
 class MapActivity : AppCompatActivity(), OnMapReadyCallback {
@@ -85,6 +86,9 @@ class MapActivity : AppCompatActivity(), OnMapReadyCallback {
     // Activity indicator
     private var progressCounter: ProgressCounter? = null
 
+    // Animation values
+    private var shortAnimationDuration: Int = 0
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -98,6 +102,9 @@ class MapActivity : AppCompatActivity(), OnMapReadyCallback {
         // Initialize the action bar
         setSupportActionBar(this.binding.mainActionBar)
         supportActionBar!!.title = getString(R.string.activity_map)
+
+        // Get resource values
+        shortAnimationDuration = resources.getInteger(android.R.integer.config_shortAnimTime)
 
         // Progress counter
         this.progressCounter = ProgressCounter(binding.loadingbar)
@@ -126,12 +133,28 @@ class MapActivity : AppCompatActivity(), OnMapReadyCallback {
         this.bottomSheetBehavior!!.setBottomSheetCallback(object : BottomSheetBehavior.BottomSheetCallback() {
             override fun onStateChanged(bottomSheet: View, newState: Int) {
                 // Bottom sheet state changed
+
+                // Deselect markers when hidden
                 if (newState == BottomSheetBehavior.STATE_HIDDEN) {
                     // Clear chart data
                     this@MapActivity.binding.bottomSheetDetails.chart3days.clear()
 
                     // Deselect all markers
                     this@MapActivity.deselectMarkers()
+                }
+
+                // Show/hide grab handle
+                val grabHandle = this@MapActivity.binding.bottomSheetPeek.grabHandle
+                if (newState == BottomSheetBehavior.STATE_EXPANDED) {
+                    grabHandle.animate()
+                        .alpha(0f)
+                        .setDuration(shortAnimationDuration.toLong())
+                        .setListener(null)
+                } else {
+                    grabHandle.animate()
+                        .alpha(1f)
+                        .setDuration(shortAnimationDuration.toLong())
+                        .setListener(null)
                 }
             }
 

--- a/app/src/main/res/drawable/ic_bottom_sheet_grab_handle.xml
+++ b/app/src/main/res/drawable/ic_bottom_sheet_grab_handle.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="3dp"
+    android:viewportWidth="24"
+    android:viewportHeight="3">
+    <path
+        android:fillColor="@android:color/darker_gray"
+        android:pathData="M 1.5 0 L 22.5 0 Q 24 0 24 1.5 L 24 1.5 Q 24 3 22.5 3 L 1.5 3 Q 0 3 0 1.5 L 0 1.5 Q 0 0 1.5 0 Z"
+        android:strokeWidth="1" />
+</vector>

--- a/app/src/main/res/layout/bottom_sheet_peek.xml
+++ b/app/src/main/res/layout/bottom_sheet_peek.xml
@@ -9,7 +9,16 @@
     android:paddingBottom="16dp"
     android:paddingEnd="16dp"
     android:paddingStart="16dp"
-    android:paddingTop="16dp">
+    android:paddingTop="0dp">
+
+    <!-- Grab handle -->
+    <ImageView
+        android:id="@+id/grabHandle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:layout_centerHorizontal="true"
+        android:src="@drawable/ic_bottom_sheet_grab_handle" />
 
     <!-- Device name -->
     <TextView
@@ -17,6 +26,7 @@
         style="@style/TextAppearance.AppCompat.Headline"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
         android:layout_marginBottom="8dp" />
 
     <!-- Caption -->


### PR DESCRIPTION
The grab handle makes it more obvious that the bottom sheet can be dragged.

It is hidden (with an animation) when the bottom sheet is fully expanded, and shown again when collapsed.

![image](https://user-images.githubusercontent.com/105168/154750476-45f55c3a-3cb2-4b15-8dd7-a5b405709cf6.png)
