### PR TITLE
Upgrade MapLibre: 9.5 → 10.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![CircleCI][circle-ci-badge]][circle-ci]
 
-Android app written in Kotlin. Work in progress. Uses Mapbox API.
+Android app written in Kotlin. Displays temperature sensor data on a map (Maplibre SDK, map data
+provided by Mapbox).
 
 ## Building
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -117,7 +117,7 @@ dependencies {
     implementation "com.github.skydoves:landscapist-glide:1.4.9"
 
     // Maplibre SDK
-    implementation 'org.maplibre.gl:android-sdk:9.5.2'
+    implementation 'org.maplibre.gl:android-sdk:10.2.0'
     implementation 'org.maplibre.gl:android-plugin-annotation-v9:1.0.0'
 
     // REST client

--- a/app/src/main/java/ch/coredump/watertemp/activities/MapActivity.kt
+++ b/app/src/main/java/ch/coredump/watertemp/activities/MapActivity.kt
@@ -151,7 +151,7 @@ class MapActivity : ComponentActivity() {
 
             // Load marker icon
             style.addImage(MARKER_DEFAULT, ContextCompat.getDrawable(this, R.drawable.blue_marker)!!)
-            style.addImage(MARKER_ACTIVE, ContextCompat.getDrawable(this, com.mapbox.mapboxsdk.R.drawable.mapbox_marker_icon_default)!!)
+            style.addImage(MARKER_ACTIVE, ContextCompat.getDrawable(this, com.mapbox.mapboxsdk.R.drawable.maplibre_marker_icon_default)!!)
 
             // Initialize symbol manager
             this.symbolManager = SymbolManager(mapView, mapboxMap, style)
@@ -708,7 +708,7 @@ class MapActivity : ComponentActivity() {
                     BuildConfig.MAPBOX_ACCESS_TOKEN,
                     WellKnownTileServer.Mapbox
                 )
-                val mapOptions = MapboxMapOptions()
+                val mapOptions = MapboxMapOptions.createFromAttributes(context)
                     .logoEnabled(false)
                     .attributionMargins(intArrayOf(10, 10, 10, 10))
                     .camera(


### PR DESCRIPTION
This also gets rid of the transitive GMS dependencies.

Fixes #57.