### PR TITLE
Exclude dependencies info when building APK

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,6 +33,13 @@ android {
         testInstrumentationRunnerArguments disableAnalytics: 'true'
     }
 
+    dependenciesInfo {
+        // Disable dependency metadata when building APKs
+        includeInApk = false
+        // Include dependency metadata when building Android App Bundles
+        includeInBundle = true
+    }
+
     androidResources {
         generateLocaleConfig true
     }


### PR DESCRIPTION
Fixes #65.