### PR TITLE
Increase minSdkVersion from 21 (Android 5) to 26 (Android 8)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,10 +72,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - api-level: 21
+          - api-level: 27 # Note: 26 had issues with missing WebView
             target: default
             arch: x86
-          - api-level: 34
+          - api-level: 35
             target: google_apis
             arch: x86_64
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,7 +36,7 @@ android {
     defaultConfig {
         applicationId "ch.coredump.watertemp"
         applicationIdSuffix ".zh"
-        minSdkVersion 21
+        minSdkVersion 26
         targetSdk 35
         compileSdk 35
         versionCode 17


### PR DESCRIPTION
The reason is that Android versions below 7.1 aren't even compatible with the Let's Encrypt root certificate used by the API server.

Android 8 seems like a workable minimal target for now.