### PR TITLE
CI: Enable -gpu swiftshader_indirect for emulator

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,9 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle-
 
+      - name: Install emulator dependencies
+        run: sudo apt-get install -y libpulse0
+
       - name: Enable KVM group perms
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
@@ -113,6 +116,7 @@ jobs:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
           arch: ${{ matrix.arch }}
+          emulator-options: -no-snapshot-save -noaudio -no-boot-anim -no-window -gpu swiftshader_indirect
           script: ./gradlew connectedDebugAndroidTest
 
       - name: Upload android test reports


### PR DESCRIPTION
This allows running MapLibre with Vulkan backend on the emulator.